### PR TITLE
fix(deploy): Netlify root serves /public-process/* assets (was unstyled raw HTML)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+# This site deploys to two targets: GitHub Pages at organvm.github.io/public-process/
+# (which needs the Jekyll `baseurl: "/public-process"` set in _config.yml) and Netlify
+# at the ROOT domain public-process.netlify.app. With baseurl set, every stylesheet and
+# nav link is emitted as `/public-process/...`, which 404s on the Netlify root — the site
+# renders as unstyled raw HTML. Netlify reads this file from the repo root directly
+# (Jekyll ignores `_`-prefixed files like `_redirects`, so a redirects file would never
+# ship). The 200 rewrite serves the real root-level asset for any `/public-process/*`
+# request, fixing Netlify without disturbing the Pages subpath deploy.
+[[redirects]]
+  from = "/public-process/*"
+  to = "/:splat"
+  status = 200


### PR DESCRIPTION
**Root cause.** Jekyll `baseurl: '/public-process'` (needed for the GitHub Pages subpath at organvm.github.io/public-process/) makes every stylesheet/nav URL `/public-process/…` — which **404s on the Netlify root domain** (public-process.netlify.app). Verified: `/public-process/assets/css/style.css` → 404 on Netlify. The site rendered as unstyled raw HTML (DECORVM visual finding, verdict: fail).

**Fix.** `netlify.toml` at repo root (Jekyll ignores `_`-prefixed files, so a `_redirects` file would never ship) — a **200 rewrite** `/public-process/* /:splat` serves the real root-level asset. Fixes the judged Netlify surface without disturbing the Pages deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)